### PR TITLE
Peer dependency react 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "peerDependencies": {
-    "react": "^17.0.2"
+    "react": "^17 || ^18"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.12.0",


### PR DESCRIPTION
Enable peer dependency for react 18. Addresses [issue 25](https://github.com/arunghosh/react-grid-heatmap/issues/25)